### PR TITLE
Allow toggling of mesh split via command line.

### DIFF
--- a/src/AssimpWorker/import/AssimpImporter.cpp
+++ b/src/AssimpWorker/import/AssimpImporter.cpp
@@ -24,6 +24,7 @@ namespace AssimpWorker {
 	const aiScene* AssimpImporter::importSceneFromFile(std::string fileName, Log& log){
 		importer.SetPropertyBool(AI_CONFIG_PP_FD_REMOVE, true); //remove degenerate polys
 		importer.SetPropertyInteger(AI_CONFIG_PP_SBP_REMOVE, aiPrimitiveType_LINE | aiPrimitiveType_POINT); //Drop all primitives that aren't triangles
+		importer.SetPropertyInteger(AI_CONFIG_PP_SLM_VERTEX_LIMIT, 65535); // Split meshes at uint16 WebGL limit
 		const aiScene* scene = importer.ReadFile(fileName, aiProcessPreset_TargetRealtime_Quality);
 		if (!scene) {
 			log.error("Scene not imported: "+fileName);

--- a/src/AssimpWorker/import/AssimpImporter.cpp
+++ b/src/AssimpWorker/import/AssimpImporter.cpp
@@ -25,7 +25,7 @@ namespace AssimpWorker {
 		importer.SetPropertyBool(AI_CONFIG_PP_FD_REMOVE, true); //remove degenerate polys
 		importer.SetPropertyInteger(AI_CONFIG_PP_SBP_REMOVE, aiPrimitiveType_LINE | aiPrimitiveType_POINT); //Drop all primitives that aren't triangles
 		importer.SetPropertyInteger(AI_CONFIG_PP_SLM_VERTEX_LIMIT, 65535); // Split meshes at uint16 WebGL limit
-		const aiScene* scene = importer.ReadFile(fileName, aiProcessPreset_TargetRealtime_Quality);
+		const aiScene* scene = importer.ReadFile(fileName, aiProcessPreset_TargetRealtime_MaxQuality);
 		if (!scene) {
 			log.error("Scene not imported: "+fileName);
 		}

--- a/src/AssimpWorker/import/AssimpImporter.hpp
+++ b/src/AssimpWorker/import/AssimpImporter.hpp
@@ -24,6 +24,7 @@ namespace AssimpWorker {
 
 	private:
 		Assimp::Importer importer;
+		void setOptions();
 	};
 
 } // End namespace AssimpWorker

--- a/src/AssimpWorker/internal/configuration.cpp
+++ b/src/AssimpWorker/internal/configuration.cpp
@@ -117,5 +117,10 @@ const bpo::variable_value& Configuration::get(const std::string &entry) const {
 	return parsedVariables[entry];
 }
 
+const bool Configuration::enabled(const std::string& entry) const
+{
+	return parsedVariables.count(entry);
+}
+
 }
 

--- a/src/AssimpWorker/internal/configuration.cpp
+++ b/src/AssimpWorker/internal/configuration.cpp
@@ -85,6 +85,11 @@ void Configuration::setupOptions() {
 		("config,c", bpo::value<std::string>(), "read configuration from file, overrides options given on command line")
 		("decompression-path", bpo::value<std::string>()->default_value("./tmp"), "Path to temporary space for decompressed zip contents")
 	;
+	bpo::options_description import("Import options");
+	import.add_options()
+		("mesh-split", "Split meshes larger than a certain number of vertices.")
+		("mesh-split-threshold", bpo::value<int>()->default_value(65535), "Number of vertices at which to split.")
+	;
 	bpo::options_description stomp("Stomp options");
 	stomp.add_options()
 		("stomp-heartbeat-interval-ms", bpo::value<int>()->default_value(10000), "Heartbeat interval in ms")
@@ -109,6 +114,7 @@ void Configuration::setupOptions() {
 	;
 
 	description.add(basic);
+	description.add(import);
 	description.add(stomp);
 	description.add(jcr);
 }

--- a/src/AssimpWorker/internal/configuration.hpp
+++ b/src/AssimpWorker/internal/configuration.hpp
@@ -19,6 +19,7 @@ class Configuration
 		void init(int argc, char** argv);
 		// get() is very read-only, you should be able to call it safely from anywhere.
 		const boost::program_options::variable_value& get(const std::string& entry) const;
+		const bool enabled(const std::string& entry) const;
 	private:
 		Configuration();
 		void setupOptions();


### PR DESCRIPTION
I feel like ATLAS should strive to minimize modification of assets in the import process and mesh splitting is a workaround to a downstream issue. However, the issue exists downstream and ATLAS is an easy place to workaround in (since Assimp conveniently offers the functionality).

Hence, an opt-in version of the mesh-splitting feature.
