### PR TITLE
Small logging improvements

### DIFF
--- a/src/AssimpWorker/import/AssimpImporter.cpp
+++ b/src/AssimpWorker/import/AssimpImporter.cpp
@@ -28,7 +28,11 @@ namespace AssimpWorker {
 		if (!scene) {
 			log.error("Scene not imported: "+fileName);
 		}
-		log.error(importer.GetErrorString());
+		const char* errorString = importer.GetErrorString();
+		if (strlen(errorString) != 0) {
+			// error string is not empty: an error occured.
+			log.error(fileName + ": " + errorString);
+		}
 		return scene;
 	}
 

--- a/src/AssimpWorker/import/Log.cpp
+++ b/src/AssimpWorker/import/Log.cpp
@@ -31,15 +31,27 @@ void Log::info(const std::string& message) {
 
 std::string Log::getAllErrors() {
 	std::stringstream out;
-	for (auto errorMessage : errors) {
-		out << errorMessage << std::endl;
+	if (errors.size() == 0) {
+		out << "No errors found during import." << std::endl;
+	} else {
+		out << errors.size() << " Error messages follow." << std::endl;
+		for (auto errorMessage : errors) {
+			if (errorMessage.empty()) {
+				continue;
+			}
+			out << errorMessage << std::endl;
+		}
 	}
 	return out.str();
 }
 
 std::string Log::getAllInfos() {
 	std::stringstream out;
+	out << infos.size() << " Informational messages follow.";
 	for (auto infoMessage : infos) {
+		if (infoMessage.empty()) {
+			continue;
+		}
 		out << infoMessage << std::endl;
 	}
 	return out.str();


### PR DESCRIPTION
– Don't spam the log message with empty lines
– Include the file name when logging an import error
– Explicitly state when no errors occurred.
